### PR TITLE
Adds tests for Buffer equality checking and adds Buffers to the list of supported structures in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ deepEq(new Set(['a', [1, 2, 3]]), new Set(['a', ['1', '2', '3']]), true) // true
 * Dates (millisecond value comparison)
 * Regular expressions
 * Errors
+* [Buffers](https://nodejs.org/api/buffer.html)
 * Nested object checking for
   * POJOs (plain objects like {'a': 1})
   * Arrays

--- a/test/buffers.js
+++ b/test/buffers.js
@@ -1,0 +1,14 @@
+const test = require('tape')
+const equal = require('../index.js')
+
+test('buffers made with .from', assert => {
+  assert.true(equal(Buffer.from('foo'), Buffer.from('foo')))
+  assert.false(equal(Buffer.from('foo'), Buffer.from('bar')))
+  assert.end()
+})
+
+test('buffers made with .alloc', assert => {
+  assert.true(equal(Buffer.alloc(10), Buffer.alloc(10)))
+  assert.false(equal(Buffer.alloc(10), Buffer.alloc(1)))
+  assert.end()
+})


### PR DESCRIPTION
They were already supported through the POJO logic branch.

It may be possible to do a more efficient implementation because the values are guaranteed to be primitives. This may be more worth exploring if/when benchmarking is added to the project.

Closes #1 