### PR TITLE
TypedArray Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ deepEq(new Set(['a', [1, 2, 3]]), new Set(['a', ['1', '2', '3']]), true) // true
 * Dates (millisecond value comparison)
 * Regular expressions
 * Errors
+* [TypedArrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
 * Nested object checking for
   * POJOs (plain objects like {'a': 1})
   * Arrays

--- a/test/typed-arrays.js
+++ b/test/typed-arrays.js
@@ -1,0 +1,107 @@
+const test = require('tape')
+const equal = require('../index.js')
+
+test('equal Float32Arrays', assert => {
+  assert.true(equal(new Float32Array([1, 2]), new Float32Array([1, 2])))
+  assert.end()
+})
+
+test('equal Float32Arrays', assert => {
+  assert.true(equal(new Float32Array([1, 2]), new Float32Array([1, 2])))
+  assert.end()
+})
+
+test('equal Float64Arrays', assert => {
+  assert.true(equal(new Float64Array([1, 2]), new Float64Array([1, 2])))
+  assert.end()
+})
+
+test('equal Float64Arrays', assert => {
+  assert.true(equal(new Float64Array([1, 2]), new Float64Array([1, 2])))
+  assert.end()
+})
+
+test('equal Int16Arrays', assert => {
+  assert.true(equal(new Int16Array([1, 2]), new Int16Array([1, 2])))
+  assert.end()
+})
+
+test('equal Int16Arrays', assert => {
+  assert.true(equal(new Int16Array([1, 2]), new Int16Array([1, 2])))
+  assert.end()
+})
+
+test('equal Int32Arrays', assert => {
+  assert.true(equal(new Int32Array([1, 2]), new Int32Array([1, 2])))
+  assert.end()
+})
+
+test('equal Int32Arrays', assert => {
+  assert.true(equal(new Int32Array([1, 2]), new Int32Array([1, 2])))
+  assert.end()
+})
+
+test('equal Int8Arrays', assert => {
+  assert.true(equal(new Int8Array([1, 2]), new Int8Array([1, 2])))
+  assert.end()
+})
+
+test('equal Int8Arrays', assert => {
+  assert.true(equal(new Int8Array([1, 2]), new Int8Array([1, 2])))
+  assert.end()
+})
+
+test('equal Uint16Arrays', assert => {
+  assert.true(equal(new Uint16Array([1, 2]), new Uint16Array([1, 2])))
+  assert.end()
+})
+
+test('equal Uint16Arrays', assert => {
+  assert.true(equal(new Uint16Array([1, 2]), new Uint16Array([1, 2])))
+  assert.end()
+})
+
+test('equal Uint32Arrays', assert => {
+  assert.true(equal(new Uint32Array([1, 2]), new Uint32Array([1, 2])))
+  assert.end()
+})
+
+test('equal Uint32Arrays', assert => {
+  assert.true(equal(new Uint32Array([1, 2]), new Uint32Array([1, 2])))
+  assert.end()
+})
+
+test('equal Uint8Arrays', assert => {
+  assert.true(equal(new Uint8Array([1, 2]), new Uint8Array([1, 2])))
+  assert.end()
+})
+
+test('equal Uint8Arrays', assert => {
+  assert.true(equal(new Uint8Array([1, 2]), new Uint8Array([1, 2])))
+  assert.end()
+})
+
+test('equal Uint8ClampedArrays', assert => {
+  assert.true(equal(new Uint8ClampedArray([1, 2]), new Uint8ClampedArray([1, 2])))
+  assert.end()
+})
+
+test('equal Uint8ClampedArrays', assert => {
+  assert.true(equal(new Uint8ClampedArray([1, 2]), new Uint8ClampedArray([1, 2])))
+  assert.end()
+})
+
+test('typed arrays of different sizes', assert => {
+  assert.false(equal(new Uint16Array([1, 2]), new Uint16Array([1])))
+  assert.end()
+})
+
+test('typed arrays with different content', assert => {
+  assert.false(equal(new Uint16Array([1, 2]), new Uint16Array([2, 3])))
+  assert.end()
+})
+
+test('typed arrays with different order of same content', assert => {
+  assert.false(equal(new Uint16Array([1, 2]), new Uint16Array([2, 1])))
+  assert.end()
+})


### PR DESCRIPTION
Adds tests for TypedArray equality checking and adds TypedArrays to the list of supported structures in the README. They were already supported through the POJO logic branch.

It may be possible to do a more efficient implementation because the values are guaranteed to be primitives. This may be more worth exploring if/when benchmarking is added to the project.

Closes #4 